### PR TITLE
feat : 상세페이지 구현

### DIFF
--- a/src/app/(route)/stores/[id]/page.tsx
+++ b/src/app/(route)/stores/[id]/page.tsx
@@ -1,3 +1,122 @@
-export default function StoreDetailPage() {
-  return <div>StoreDetailPage</div>;
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+import Link from "next/link";
+import Loader from "@/components/Loader";
+import Map from "@/components/Map";
+import Marker from "@/components/Marker";
+
+export default function StoreDetailPage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const id = params.id;
+  const fetchStore = async () => {
+    const { data } = await axios(`/api/stores?id=${id}`);
+    return data;
+  };
+
+  const {
+    data: store,
+    isError,
+    isFetching,
+    isSuccess,
+  } = useQuery({
+    queryKey: [`store-${id}`],
+    queryFn: fetchStore,
+  });
+
+  if (isError) {
+    return (
+      <div className="w-full h-screen mx-auto pt-[10%] text-red-500 text-center font-semibold">
+        다시 시도해주세요.
+      </div>
+    );
+  }
+
+  if (isFetching) return <Loader className="mt-[20%]" />;
+
+  return (
+    <>
+      <div className="max-w-5xl mx-auto px-4 py-8 ">
+        <div className="md:flex justify-between items-center py-4 md:py-0">
+          <div className="px-4 sm:px-0">
+            <h3 className="text-base font-semibold leading-7 text-gray-900">
+              {store?.name}
+            </h3>
+          </div>
+          {store && (
+            <div className="flex items-center gap-4 px-4 py-3">
+              <Link
+                className="underline hover:text-gray-400 text-sm"
+                href={`/stores/${store?.id}/edit`}>
+                수정
+              </Link>
+              <button
+                type="button"
+                className="underline  hover:text-gray-400 text-sm">
+                삭제
+              </button>
+            </div>
+          )}
+        </div>
+        <div className="mt-6 border-t border-gray-100">
+          <dl className="divide-y divide-gray-100">
+            <div className="px-4 py-6 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-0">
+              <dt className="text-sm font-medium leading-6 text-gray-900">
+                주소
+              </dt>
+              <dd className="mt-1 text-sm leading-6 text-gray-700 sm:col-span-2 sm:mt-0">
+                {store?.address}
+              </dd>
+            </div>
+            <div className="px-4 py-6 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-0">
+              <dt className="text-sm font-medium leading-6 text-gray-900">
+                메뉴
+              </dt>
+              <dd className="mt-1 text-sm leading-6 text-gray-700 sm:col-span-2 sm:mt-0">
+                {store?.menu}
+              </dd>
+            </div>
+            <div className="px-4 py-6 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-0">
+              <dt className="text-sm font-medium leading-6 text-gray-900">
+                영업시간
+              </dt>
+              <dd className="mt-1 text-sm leading-6 text-gray-700 sm:col-span-2 sm:mt-0">
+                {store?.time}
+              </dd>
+            </div>
+            <div className="px-4 py-6 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-0">
+              <dt className="text-sm font-medium leading-6 text-gray-900">
+                연락처
+              </dt>
+              <dd className="mt-1 text-sm leading-6 text-gray-700 sm:col-span-2 sm:mt-0">
+                {store?.phone}
+              </dd>
+            </div>
+            {store?.homepageUrl && (
+              <div className="px-4 py-6 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-0">
+                <dt className="text-sm font-medium leading-6 text-gray-900">
+                  홈페이지
+                </dt>
+                <dd className="mt-1 text-sm leading-6 text-gray-700 sm:col-span-2 sm:mt-0">
+                  {store?.homepageUrl}
+                </dd>
+              </div>
+            )}
+          </dl>
+        </div>
+      </div>
+      {isSuccess && (
+        <>
+          <div className="detail-map overflow-hidden w-full mb-20 max-w-5xl mx-auto max-h-[600px]">
+            <Map lat={store?.lat} lng={store?.lng} zoom={1} />
+            <Marker store={store} />
+          </div>
+        </>
+      )}
+    </>
+  );
 }

--- a/src/app/api/stores/route.ts
+++ b/src/app/api/stores/route.ts
@@ -7,6 +7,7 @@ export async function GET(req: Request) {
   const limit = searchParams.get("limit") as string;
   const query = searchParams.get("query");
   const district = searchParams.get("district");
+  const id = searchParams.get("id");
 
   if (page) {
     const count = await prisma.store.count();
@@ -35,9 +36,12 @@ export async function GET(req: Request) {
   } else {
     const stores = await prisma.store.findMany({
       orderBy: { id: "asc" },
+      where: {
+        id: id ? parseInt(id) : {},
+      },
     });
 
-    return NextResponse.json(stores, {
+    return NextResponse.json(id ? stores[0] : stores, {
       status: 200,
     });
   }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -14,6 +14,10 @@
   @apply text-gray-500;
 }
 
+.layout {
+  @apply pt-[52px];
+}
+
 .navbar__button {
   @apply hidden cursor-pointer;
 }
@@ -45,4 +49,13 @@
 
 .infowindow {
   @apply bg-blue-900 text-white block text-sm text-center h-6 rounded-sm px-2 leading-6;
+}
+
+#map {
+  width: 100%;
+  height: 100vh;
+}
+
+.detail-map #map {
+  height: 600px;
 }

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -47,7 +47,7 @@ export default function Map({ lat, lng, zoom }: MapProps) {
         src={`//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_MAP_CLIENT}&autoload=false`}
         onReady={loadKakaoMap}
       />
-      <div id="map" className="w-full h-screen"></div>
+      <div id="map"></div>
     </>
   );
 }

--- a/src/components/Marker.tsx
+++ b/src/components/Marker.tsx
@@ -1,0 +1,49 @@
+import { useCallback, useContext, useEffect } from "react";
+import MapContext from "@/context/MapContext";
+import { StoreType } from "@/interface";
+
+interface MakerProps {
+  store: StoreType;
+}
+
+export default function Marker({ store }: MakerProps) {
+  const context = useContext(MapContext);
+
+  const loadKakoMarker = useCallback(() => {
+    if (context?.map && store) {
+      const markerPosition = new window.kakao.maps.LatLng(
+        store?.lat,
+        store?.lng
+      );
+
+      var marker = new window.kakao.maps.Marker({
+        position: markerPosition,
+      });
+
+      marker.setMap(context?.map);
+
+      var content = `<div class="infowindow">${store?.name}</div>`;
+
+      var customOverlay = new window.kakao.maps.CustomOverlay({
+        position: markerPosition,
+        content: content,
+        xAnchor: 0.6,
+        yAnchor: 0.91,
+      });
+
+      window.kakao.maps.event.addListener(marker, "mouseover", function () {
+        customOverlay.setMap(context?.map);
+      });
+
+      window.kakao.maps.event.addListener(marker, "mouseout", function () {
+        customOverlay.setMap(null);
+      });
+    }
+  }, [context?.map, store]);
+
+  useEffect(() => {
+    loadKakoMarker();
+  }, [loadKakoMarker, context?.map]);
+
+  return <></>;
+}


### PR DESCRIPTION
## 작업내용

1. 상세 페이지 구현
- store API에서 id로 데이터 불러올 수 있도록 수정
- Marker 컴포넌트 생성 ( 선택한 가게만 보이도록 한개의 마커만 구현 )
- Map 컴포넌트 css 수정
- StoreDetailPage 컴포넌트 생성

  <br/>

## 이미지 첨부

<img width="1583" alt="스크린샷 2024-07-09 오후 6 14 16" src="https://github.com/jm-316/Taste-Busan/assets/130331748/46f8e80a-204c-4184-9513-59aecdf405c1">

<br/>

## 앞으로의 과제

- 로그인 구현

  <br/>