### PR TITLE
feat : 찜 기능 구현

### DIFF
--- a/next-auth.d.ts
+++ b/next-auth.d.ts
@@ -1,0 +1,12 @@
+import NextAuth from "next-auth";
+
+declare module "next-auth" {
+  interface Session {
+    user: {
+      id: string;
+      name?: string;
+      email?: string;
+      image?: string;
+    };
+  }
+}

--- a/prisma/migrations/20240711080605_add/migration.sql
+++ b/prisma/migrations/20240711080605_add/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "Like" (
+    "id" SERIAL NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "storeId" INTEGER NOT NULL,
+    "userId" INTEGER NOT NULL,
+
+    CONSTRAINT "Like_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Like_userId_storeId_idx" ON "Like"("userId", "storeId");
+
+-- AddForeignKey
+ALTER TABLE "Like" ADD CONSTRAINT "Like_storeId_fkey" FOREIGN KEY ("storeId") REFERENCES "Store"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Like" ADD CONSTRAINT "Like_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -17,10 +17,11 @@ model User {
   id        Int     @id @default(autoincrement())
   email     String?  @unique
   name      String?
-  image         String?
+  image     String?
   emailVerified DateTime?
-  accounts      Account[]
-  sessions      Session[]
+  accounts  Account[]
+  sessions  Session[]
+  likes     Like[]
 }
 
 model Store {
@@ -34,6 +35,17 @@ model Store {
   time      String?
   homepage  String?
   localCategory String?
+  likes     Like[]
+}
+
+model Like {
+  id        Int     @id @default(autoincrement())
+  createdAt DateTime @default(now())
+  storeId   Int
+  userId    Int
+  store     Store   @relation(fields: [storeId], references: [id], onDelete: Cascade)
+  user      User    @relation(fields: [userId], references: [id], onDelete: Cascade)
+  @@index([userId, storeId])
 }
 
 model Account {

--- a/src/app/(route)/stores/[id]/edit/page.tsx
+++ b/src/app/(route)/stores/[id]/edit/page.tsx
@@ -22,7 +22,7 @@ export default function StoreEditPage({ params }: { params: { id: string } }) {
 
   const fetchStore = async () => {
     const { data } = await axios(`/api/stores?id=${id}`);
-    console.log(data);
+
     setValue("id", data.id);
     setValue("name", data.name);
     setValue("phone", data.phone);

--- a/src/app/(route)/stores/[id]/page.tsx
+++ b/src/app/(route)/stores/[id]/page.tsx
@@ -9,6 +9,7 @@ import Link from "next/link";
 import Loader from "@/components/Loader";
 import Map from "@/components/Map";
 import Marker from "@/components/Marker";
+import Like from "@/components/Like";
 
 export default function StoreDetailPage({
   params,
@@ -77,6 +78,7 @@ export default function StoreDetailPage({
           </div>
           {status === "authenticated" && store && (
             <div className="flex items-center gap-4 px-4 py-3">
+              <Like storeId={store.id} />
               <Link
                 className="underline hover:text-gray-400 text-sm"
                 href={`/stores/${store?.id}/edit`}>

--- a/src/app/(route)/users/likes/page.tsx
+++ b/src/app/(route)/users/likes/page.tsx
@@ -1,3 +1,65 @@
-export default function LikesPage() {
-  return <div>LikesPage</div>;
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+import { LikeApiResponse, LikeInterface } from "@/interface";
+import StoreList from "@/components/StoreList";
+import Loading from "@/components/Loading";
+import Pagination from "@/components/Pagination";
+
+export default function LikesPage({
+  searchParams,
+}: {
+  searchParams: { page: string };
+}) {
+  const page = searchParams?.page || "1";
+
+  const fetchLikes = async () => {
+    const { data } = await axios(`/api/likes?limit=10&page=${page}`);
+    return data as LikeApiResponse;
+  };
+
+  const {
+    data: likes,
+    isError,
+    isLoading,
+    isSuccess,
+  } = useQuery({
+    queryKey: [`likes-${page}`],
+    queryFn: fetchLikes,
+  });
+
+  if (isError) {
+    return (
+      <div className="w-full h-screen mx-auto pt-[10%] text-red-500 text-center font-semibold">
+        다시 시도해주세요.
+      </div>
+    );
+  }
+
+  return (
+    <div className="px-4 md:max-w-4xl mx-auto py-8">
+      <h3 className="text-lg font-semibold">찜한 맛집</h3>
+      <div className="mt-1 text-gray-500 text-sm">찜한 가게 리스트입니다.</div>
+      <ul role="list" className="divide-y divide-gray-100 mt-10">
+        {isLoading ? (
+          <Loading />
+        ) : (
+          likes?.data.map((like: LikeInterface, index) => (
+            <StoreList store={like.store} key={index} />
+          ))
+        )}
+        {isSuccess && !!!likes.data.length && (
+          <div className="p-4 border border-gray-200 rounded-md text-sm text-gray-400">
+            찜한 가게가 없습니다.
+          </div>
+        )}
+      </ul>
+      <Pagination
+        total={likes?.totalPage}
+        page={page}
+        pathname="/users/likes"
+      />
+    </div>
+  );
 }

--- a/src/app/api/likes/route.ts
+++ b/src/app/api/likes/route.ts
@@ -3,10 +3,61 @@ import { authOptions } from "../auth/[...nextauth]/route";
 import { NextResponse } from "next/server";
 import prisma from "@/db";
 
+export async function GET(req: Request) {
+  const session = await getServerSession(authOptions);
+  const { searchParams } = new URL(req.url);
+  const page = searchParams.get("page") as string;
+  const limit = searchParams.get("limit") as string;
+
+  if (!session?.user) {
+    return NextResponse.json(null, {
+      status: 401,
+    });
+  }
+
+  const count = await prisma.like.count({
+    where: {
+      userId: parseInt(session?.user?.id),
+    },
+  });
+
+  const skipPage = parseInt(page) - 1;
+  const likes = await prisma.like.findMany({
+    orderBy: {
+      createdAt: "desc",
+    },
+    where: {
+      userId: parseInt(session?.user?.id),
+    },
+    include: {
+      store: true,
+    },
+    skip: skipPage * parseInt(limit),
+    take: parseInt(limit),
+  });
+
+  return NextResponse.json(
+    {
+      data: likes,
+      page: parseInt(page),
+      totalPage: Math.ceil(count / parseInt(limit)),
+    },
+    {
+      status: 200,
+    }
+  );
+}
+
 export async function POST(req: Request) {
   const session = await getServerSession(authOptions);
   const body = await req.json();
   const { storeId } = body;
+
+  if (!session?.user) {
+    return NextResponse.json(null, {
+      status: 401,
+    });
+  }
 
   let like = await prisma.like.findFirst({
     where: {

--- a/src/app/api/likes/route.ts
+++ b/src/app/api/likes/route.ts
@@ -1,0 +1,40 @@
+import { getServerSession } from "next-auth";
+import { authOptions } from "../auth/[...nextauth]/route";
+import { NextResponse } from "next/server";
+import prisma from "@/db";
+
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions);
+  const body = await req.json();
+  const { storeId } = body;
+
+  let like = await prisma.like.findFirst({
+    where: {
+      storeId,
+      userId: parseInt(session?.user?.id as string),
+    },
+  });
+
+  if (like) {
+    await prisma.like.delete({
+      where: {
+        id: like.id,
+      },
+    });
+
+    return NextResponse.json(null, {
+      status: 200,
+    });
+  } else {
+    like = await prisma.like.create({
+      data: {
+        storeId,
+        userId: parseInt(session?.user?.id as string),
+      },
+    });
+
+    return NextResponse.json(like, {
+      status: 201,
+    });
+  }
+}

--- a/src/app/api/stores/route.ts
+++ b/src/app/api/stores/route.ts
@@ -1,5 +1,7 @@
 import axios from "axios";
 import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "../auth/[...nextauth]/route";
 import prisma from "@/db";
 
 export async function GET(req: Request) {
@@ -9,6 +11,8 @@ export async function GET(req: Request) {
   const query = searchParams.get("query");
   const district = searchParams.get("district");
   const id = searchParams.get("id");
+
+  const session = await getServerSession(authOptions);
 
   if (page) {
     const count = await prisma.store.count();
@@ -39,6 +43,11 @@ export async function GET(req: Request) {
       orderBy: { id: "asc" },
       where: {
         id: id ? parseInt(id) : {},
+      },
+      include: {
+        likes: {
+          where: session ? { userId: parseInt(session?.user?.id) } : {},
+        },
       },
     });
 

--- a/src/components/Like.tsx
+++ b/src/components/Like.tsx
@@ -1,0 +1,57 @@
+import { useQuery } from "@tanstack/react-query";
+import { toast } from "react-toastify";
+import { AiFillHeart, AiOutlineHeart } from "react-icons/ai";
+import axios from "axios";
+import { useSession } from "next-auth/react";
+import { StoreType } from "@/interface";
+
+interface LikeProps {
+  storeId: number;
+}
+
+export default function Like({ storeId }: LikeProps) {
+  const { data: session, status } = useSession();
+
+  const fetchStore = async () => {
+    const { data } = await axios(`/api/stores?id=${storeId}`);
+    return data as StoreType;
+  };
+
+  const { data: store, refetch } = useQuery<StoreType>({
+    queryKey: [`like-store-${storeId}`],
+    queryFn: fetchStore,
+    enabled: !!storeId,
+    refetchOnWindowFocus: false,
+  });
+
+  const toggleLike = async () => {
+    // 찜하기 및 찜취소 로직
+    if (session?.user && store) {
+      try {
+        const like = await axios.post("/api/likes", {
+          storeId: store.id,
+        });
+
+        if (like.status === 201) {
+          toast.success("가게를 찜했습니다.");
+        } else {
+          toast.warn("찜을 취소했습니다.");
+        }
+        refetch(); // 이걸 해야 하트가 제대로 변경됨
+      } catch (e) {
+        console.log(e);
+      }
+    } else if (status === "unauthenticated") {
+      toast.warn("로그인 후 이용해주세요.");
+    }
+  };
+  return (
+    <button type="button" onClick={toggleLike}>
+      {status === "authenticated" && store?.likes?.length ? (
+        <AiFillHeart className="hover:text-red-600 focus:text-red-600 text-red-500" />
+      ) : (
+        <AiOutlineHeart className="hover:text-red-600 focus:text-red-600" />
+      )}
+    </button>
+  );
+}

--- a/src/components/Like.tsx
+++ b/src/components/Like.tsx
@@ -25,7 +25,6 @@ export default function Like({ storeId }: LikeProps) {
   });
 
   const toggleLike = async () => {
-    // 찜하기 및 찜취소 로직
     if (session?.user && store) {
       try {
         const like = await axios.post("/api/likes", {
@@ -37,7 +36,7 @@ export default function Like({ storeId }: LikeProps) {
         } else {
           toast.warn("찜을 취소했습니다.");
         }
-        refetch(); // 이걸 해야 하트가 제대로 변경됨
+        refetch();
       } catch (e) {
         console.log(e);
       }

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -1,0 +1,55 @@
+import Link from "next/link";
+
+interface Pagination {
+  total?: number;
+  page: string;
+  pathname: string;
+}
+
+export default function Pagination({ total = 0, page, pathname }: Pagination) {
+  return (
+    <div className="py-6 w-full px-10 flex justify-center gap-3 bg-white my-10 flex-wrap text-black">
+      {total <= 10 ? (
+        [...Array(total)].map((x, i) => (
+          <Link href={{ pathname, query: { page: i + 1 } }} key={i}>
+            <span
+              className={`px-3 py-2 rounded border shadow-sm bg-white ${
+                i + 1 === parseInt(page, 10)
+                  ? "text-blue-600 font-bold"
+                  : "text-gray-300"
+              }`}>
+              {i + 1}
+            </span>
+          </Link>
+        ))
+      ) : (
+        <>
+          {parseInt(page) > 1 && (
+            <Link href={{ pathname, query: { page: parseInt(page) - 1 } }}>
+              <span className={`px-3 py-2 rounded border shadow-sm bg-white`}>
+                이전
+              </span>
+            </Link>
+          )}
+          <Link href={{ pathname, query: { page: parseInt(page) } }}>
+            <span
+              className={`px-3 py-2 rounded border shadow-sm bg-white text-blue-600`}>
+              {page}
+            </span>
+          </Link>
+          {total > parseInt(page) && (
+            <Link
+              href={{
+                pathname: "/stores",
+                query: { page: parseInt(page) + 1 },
+              }}>
+              <span className={`px-3 py-2 rounded border shadow-sm bg-white`}>
+                다음
+              </span>
+            </Link>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/StoreBox.tsx
+++ b/src/components/StoreBox.tsx
@@ -10,6 +10,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { RootState } from "@/store/store";
 import { setCurrentStore } from "@/slices/mapSlice";
+import Like from "./Like";
 
 export default function StoreBox() {
   const store = useSelector((state: RootState) => state.map.currentStoreState);
@@ -38,6 +39,7 @@ export default function StoreBox() {
                 <FiMapPin />
                 {store?.address || "주소가 없습니다."}
               </div>
+              <Like storeId={store?.id} />
             </div>
             <div className="mt-2 flex gap-2 items-center">
               <AiOutlinePhone />

--- a/src/interface/index.ts
+++ b/src/interface/index.ts
@@ -19,6 +19,12 @@ export interface StoreApiResponse {
   page?: number;
 }
 
+export interface LikeApiResponse {
+  data: LikeInterface[];
+  totalPage?: number;
+  page?: number;
+}
+
 export interface Location {
   lat: number;
   lng: number;

--- a/src/interface/index.ts
+++ b/src/interface/index.ts
@@ -9,6 +9,7 @@ export interface StoreType {
   time?: string | null;
   homepage?: string | null;
   localCategory?: string | null;
+  likes?: LikeInterface[];
 }
 
 export interface StoreApiResponse {
@@ -27,4 +28,11 @@ export interface Location {
 export interface SearchType {
   query?: string;
   district?: string;
+}
+
+export interface LikeInterface {
+  id: number;
+  storeId: number;
+  userId: number;
+  store?: StoreType;
 }


### PR DESCRIPTION
## 작업내용

1. 찜 기능 구현
- Like 컴포넌트 생성 (하트 클릭시 DB에 like의 id의 추가되거나 삭제됨)
- StoreBox와 StoreDetailPage에 Like 컴포넌트 추가

3. 찜한 가게 페이지 구현
- Pagination 컴포넌트 생성
- store GET API 수정
- likes API GET과 POST 작성
- LikesPage 페이지 작성

4. user 타입 재정의
- next-auth.d.ts 파일 생성

  <br/>

## 이미지 첨부
<img width="1583" alt="스크린샷 2024-07-12 오후 3 26 38" src="https://github.com/user-attachments/assets/8b2d920b-8a35-45a5-a5f9-6b43bdccb43e">
<img width="1583" alt="스크린샷 2024-07-12 오후 3 26 31" src="https://github.com/user-attachments/assets/937b0119-5b4d-42f2-b18b-137412f1d953">
<img width="1583" alt="스크린샷 2024-07-12 오후 3 24 11" src="https://github.com/user-attachments/assets/e6d25fcd-4e6a-4139-a393-a8e222b6df5e">

<br/>

## 앞으로의 과제

- 마이페이지 작업

  <br/>
