### PR TITLE
feat : 마이페이지 구현

### DIFF
--- a/prisma/migrations/20240712070452_add/migration.sql
+++ b/prisma/migrations/20240712070452_add/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "Store" ADD COLUMN     "userId" INTEGER NOT NULL DEFAULT 1;
+
+-- CreateIndex
+CREATE INDEX "Store_userId_idx" ON "Store"("userId");
+
+-- AddForeignKey
+ALTER TABLE "Store" ADD CONSTRAINT "Store_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,10 +22,12 @@ model User {
   accounts  Account[]
   sessions  Session[]
   likes     Like[]
+  stores    Store[]
 }
 
 model Store {
   id        Int     @id @default(autoincrement())
+  userId    Int     @default(1)
   phone     String?
   address   String?
   lat       Float?
@@ -36,6 +38,8 @@ model Store {
   homepage  String?
   localCategory String?
   likes     Like[]
+  user      User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  @@index([userId])
 }
 
 model Like {

--- a/src/app/(route)/stores/new/page.tsx
+++ b/src/app/(route)/stores/new/page.tsx
@@ -1,15 +1,17 @@
 "use client";
 
 import { useForm } from "react-hook-form";
-import { useRouter } from "next/navigation";
+import { useSession } from "next-auth/react";
 import { toast } from "react-toastify";
 import axios from "axios";
+import { useRouter } from "next/navigation";
 import { DISTRICT_ARR } from "@/data/store";
 import { StoreType } from "@/interface";
 import AddressSearch from "@/components/AddressSearch";
 
 export default function StoreNewPage() {
   const router = useRouter();
+  const { data: session } = useSession();
   const {
     register,
     handleSubmit,
@@ -19,7 +21,10 @@ export default function StoreNewPage() {
 
   const onSubmit = async (data: any) => {
     try {
-      const result = await axios.post("/api/stores", data);
+      const result = await axios.post("/api/stores", {
+        ...data,
+        userId: session?.user.id,
+      });
 
       if (result.status === 200) {
         toast.success("맛집을 등록했습니다.");

--- a/src/app/(route)/users/mypage/page.tsx
+++ b/src/app/(route)/users/mypage/page.tsx
@@ -1,5 +1,108 @@
-import React from "react";
+"use client";
 
-export default function MyPage() {
-  return <div>MyPage</div>;
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+import { signOut, useSession } from "next-auth/react";
+import { StoreApiResponse } from "@/interface";
+import Pagination from "@/components/Pagination";
+import StoreList from "@/components/StoreList";
+
+export default function MyPage({
+  searchParams,
+}: {
+  searchParams: { page: string };
+}) {
+  const { data: session } = useSession();
+  const page = searchParams?.page || "1";
+
+  const fetchStores = async () => {
+    const { data } = await axios(
+      `/api/stores?&limit=10&page=${page}&mypage=${session?.user.id}`
+    );
+
+    return data as StoreApiResponse;
+  };
+
+  const { data: stores } = useQuery({
+    queryKey: [`store-${page}`],
+    queryFn: fetchStores,
+  });
+
+  return (
+    <div className="md:max-w-5xl mx-auto px-4 py-8">
+      <div className="px-4 sm:px-0">
+        <h3 className="text-base font-semibold leading-7 text-gray-900">
+          마이페이지
+        </h3>
+        <p className="mt-1 max-w-2xl text-sm leading-6 text-gray-500">
+          사용자 기본정보
+        </p>
+      </div>
+      <div className="mt-6 border-t border-gray-100">
+        <dl className="divide-y divide-gray-100">
+          <div className="px-4 py-6 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-0">
+            <dt className="text-sm font-medium leading-6 text-gray-900">
+              이름
+            </dt>
+            <dd className="mt-1 text-sm leading-6 text-gray-700 sm:col-span-2 sm:mt-0">
+              {session?.user.name ?? "사용자"}
+            </dd>
+          </div>
+          <div className="px-4 py-6 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-0">
+            <dt className="text-sm font-medium leading-6 text-gray-900">
+              이메일
+            </dt>
+            <dd className="mt-1 text-sm leading-6 text-gray-700 sm:col-span-2 sm:mt-0">
+              {session?.user.email}
+            </dd>
+          </div>
+          <div className="px-4 py-6 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-0">
+            <dt className="text-sm font-medium leading-6 text-gray-900">
+              이미지
+            </dt>
+            <dd className="mt-1 text-sm leading-6 text-gray-700 sm:col-span-2 sm:mt-0">
+              <img
+                alt="프로필 이미지"
+                width={48}
+                height={48}
+                className="rounded-full h-12 w-12"
+                src={session?.user.image || "/images/markers/default.png"}
+              />
+            </dd>
+          </div>
+          <div className="px-4 py-6 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-0">
+            <dt className="text-sm font-medium leading-6 text-gray-900">
+              설정
+            </dt>
+            <dd className="mt-1 text-sm leading-6 text-gray-700 sm:col-span-2 sm:mt-0">
+              <button
+                type="button"
+                className="underline hover:text-gray-500"
+                onClick={() => signOut()}>
+                로그아웃
+              </button>
+            </dd>
+          </div>
+        </dl>
+      </div>
+      <div className="mt-8 px-4 sm:px-0">
+        <h3 className="text-base font-semibold leading-7 text-gray-900">
+          내가 등록한 가게
+        </h3>
+        <p className="mt-1 max-w-2xl text-sm leading-6 text-gray-500">
+          가게 리스트
+        </p>
+      </div>
+      <div className="divide-y divide-gray-300 my-10">
+        {stores?.data?.map((store) => (
+          <StoreList store={store} key={store.id} />
+        ))}
+      </div>
+      <Pagination
+        total={stores?.totalPage}
+        page={page}
+        pathname="/users/mypage"
+      />
+    </div>
+  );
 }

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -40,7 +40,7 @@ export default function Pagination({ total = 0, page, pathname }: Pagination) {
           {total > parseInt(page) && (
             <Link
               href={{
-                pathname: "/stores",
+                pathname,
                 query: { page: parseInt(page) + 1 },
               }}>
               <span className={`px-3 py-2 rounded border shadow-sm bg-white`}>

--- a/src/interface/index.ts
+++ b/src/interface/index.ts
@@ -10,6 +10,7 @@ export interface StoreType {
   homepage?: string | null;
   localCategory?: string | null;
   likes?: LikeInterface[];
+  user?: UserInterface[];
 }
 
 export interface StoreApiResponse {
@@ -40,5 +41,10 @@ export interface LikeInterface {
   id: number;
   storeId: number;
   userId: number;
+  store?: StoreType;
+}
+
+export interface UserInterface {
+  id: number;
   store?: StoreType;
 }


### PR DESCRIPTION
## 작업내용

1. 마이페이지 구현
- Store 모델에 user 와 userId 추가 및 User 모델에는 stores 추가
- stores API 수정 ( mypage 관련 GET 로직 추가 및 POST에는  userId 추가)
- StoreNewPage 컴포넌트의 onSubmit 함수에 userId 추가
- MyPage 컴포넌트 작성

2. Pagination 컴포넌트 수정
- pathname를 props로 받도록 수정

  <br/>

## 이미지 첨부
<img width="1583" alt="스크린샷 2024-07-13 오후 12 05 58" src="https://github.com/user-attachments/assets/c4af3a06-9b4c-49c0-a30e-76a971a2cf4b">

<br/>

## 앞으로의 과제

- 에러페이지 구현

  <br/>